### PR TITLE
Fix for breaking links with only # as href

### DIFF
--- a/js/jquery.plusanchor.js
+++ b/js/jquery.plusanchor.js
@@ -1,12 +1,12 @@
 /*
 * PlusAnchor
-* A form component library
-* Version: "1.1.2"
+* A simple jQuery plugin that scrolls to anchor links instead of instantaneously jumping to them.
+* Version: "1.1.2.1"
 * Jamy Golden
 * https://github.com/JamyGolden/PlusAnchor
+* Fork: sean@onegiantmedia.com  |  https://github.com/sean-mystyle/PlusAnchor
 * License: MIT
-*/
-(function($){
+*/(function($){
 
     function scrollToEvent(base) {
         return function(e) {

--- a/js/jquery.plusanchor.js
+++ b/js/jquery.plusanchor.js
@@ -34,15 +34,15 @@
         var bodyEl = document.body;
 
         function _constructor() {
-			// If the user selects body, make sure to use 'html, body' for
+	    // If the user selects body, make sure to use 'html, body' for
             // cross browser compatibility reasons
-			base.el = el;
+	    base.el = el;
             base.$el = (el === htmlEl || el === bodyEl) ? $('html, body') : $(el);
             base.$animationTarget = options.animationTarget ? $(options.animationTarget) : base.$el;
             base.$el.data('plusAnchor', base); // Add a reverse reference to the DOM object
             base.animateScrolling = animateScrolling;
 			
-			var anchorSelector = options.includeCssIndication ? '.js-plus-anchor' : 'a[href^="#"]';
+	    var anchorSelector = options.includeCssIndication ? '.js-plus-anchor' : 'a[href^="#"]:not([href="#"])';// only select anchor links that are not # by itself
 			
             // Check for plusanchor disable
             if (options === false) {


### PR DESCRIPTION
This is a bug fix for links with only # as href.  You can change the header info if you want if merged back.